### PR TITLE
Liquidation edge cases

### DIFF
--- a/src/EVault/modules/Liquidation.sol
+++ b/src/EVault/modules/Liquidation.sol
@@ -129,6 +129,11 @@ abstract contract LiquidationModule is ILiquidation, Base, BalanceUtils, Liquidi
 
         uint256 collateralBalance = IERC20(liqCache.collateral).balanceOf(liqCache.violator);
         uint256 collateralValue = marketCache.oracle.getQuote(collateralBalance, liqCache.collateral, marketCache.unitOfAccount);
+        if (collateralValue == 0) {
+            // worthless collateral can be claimed with no repay
+            liqCache.yieldBalance = collateralBalance;
+            return liqCache;
+        }
 
         uint256 liabilityValue = liqCache.owed.toUint();
         if (address(marketCache.asset) != marketCache.unitOfAccount) {


### PR DESCRIPTION
Allow liquidation logic to fall through to debt socialization.

Edge cases:
1) There is debt and collateral balances, but one of the collaterals is priced 0. This collateral is liquidated.
As the collateral's price approaches zero, the liquidator will be able to grab all of it for decreasing amounts of debt to repay, down to 1 wei. If there are no other collaterals, the rest of the debt will be socialized. Collateral price = 0 does not change semantics - at limit liquidator receives all of collateral for no repay. All of the debt is socialized. 
yield = all collateral, repay = 0

note: the price doesn't need to be 0, just collateral amount in unit of account could be rounded down to 0 by the oracle.

2) There is debt and no collateral balances at all.
This should not be possible with debt socialization present, but could happen if debt socialization is off. The liquidation calculation should be 0 yield, and 0 repay. With debt socialization switched on the debt should be removed.
yield = 0, repay = 0

3) There is debt and collatreal, both with value. There is less collateral than max possible with the discount, so repay is adjusted and rounds down to 0. In effect dust collateral is removed and debt is socialized.
yield = max collateral, repay = 0

4) There is debt and collatreal, both with value. The maxYield in unit of account is < collateral value, but convertion to yieldBalance from maxYieldValue rounds down to 0. If minYield is not set liquidator takes on debt for no yield. Debt can be reduced, bringing the account back to health. No debt socialization
yield = 0, repay > 0