### PR TITLE
improve convert fees

### DIFF
--- a/src/EVault/modules/Governance.sol
+++ b/src/EVault/modules/Governance.sol
@@ -160,18 +160,19 @@ abstract contract GovernanceModule is IGovernance, Base, BalanceUtils, BorrowUti
 
         marketStorage.accumulatedFees = marketCache.accumulatedFees = Shares.wrap(0);
 
-        Assets governorAssets = governorShares.toAssetsDown(marketCache);
-        Assets protocolAssets = protocolShares.toAssetsDown(marketCache);
-
         // Decrease totalShares because increaseBalance will increase it by that total amount
         marketStorage.totalShares = marketCache.totalShares = marketCache.totalShares - marketCache.accumulatedFees;
 
-        if (governorReceiver != address(0)) {
-            increaseBalance(marketCache, governorReceiver, address(0), governorShares, governorAssets);
+        // For the Deposit events in increaseBalance the assets amount is zero - the shares are covered with the accrued interest
+        if (!governorShares.isZero()) {
+            increaseBalance(marketCache, governorReceiver, address(0), governorShares, Assets.wrap(0));
         }
 
-        increaseBalance(marketCache, protocolReceiver, address(0), protocolShares, protocolAssets);
-        emit ConvertFees(account, protocolReceiver, governorReceiver, protocolAssets.toUint(), governorAssets.toUint());
+        if (!protocolShares.isZero()) {
+            increaseBalance(marketCache, protocolReceiver, address(0), protocolShares, Assets.wrap(0));
+        }
+
+        emit ConvertFees(account, protocolReceiver, governorReceiver, protocolShares.toUint(), governorShares.toUint());
     }
 
     /// @inheritdoc IGovernance

--- a/src/EVault/shared/Events.sol
+++ b/src/EVault/shared/Events.sol
@@ -23,9 +23,9 @@ abstract contract Events {
     event ConvertFees(
         address indexed sender,
         address indexed protocolReceiver,
-        address indexed feeReceiver,
-        uint256 protocolAssets,
-        uint256 feeAssets
+        address indexed governorReceiver,
+        uint256 protocolShares,
+        uint256 governorShares
     );
 
     event MarketStatus(


### PR DESCRIPTION
To be consistent with other instances where increaseBalance is called - it's skipped for zero amount.

The Deposit events will emit 0 assets

ConvertFees will just emit exact shares amounts converted rather than converted assets