### PR TITLE
SPEARBIT-125 Don't enter `transferBorrow` when liquidation `repay` is zero

### DIFF
--- a/src/EVault/modules/Liquidation.sol
+++ b/src/EVault/modules/Liquidation.sol
@@ -174,7 +174,9 @@ abstract contract LiquidationModule is ILiquidation, Base, BalanceUtils, Liquidi
 
         // Handle repay: liquidator takes on violator's debt:
 
-        transferBorrow(vaultCache, liqCache.violator, liqCache.liquidator, liqCache.repay);
+        if (liqCache.repay.toUint() > 0) {
+            transferBorrow(vaultCache, liqCache.violator, liqCache.liquidator, liqCache.repay);
+        }
 
         // Handle yield: liquidator receives violator's collateral
 


### PR DESCRIPTION
In case of a no-op a `Liquidation` is still emitted. We could check for zero yield and repay, but then debt socialization could potentially be emitted without a Liquidation even