### PR TITLE
Update import paths

### DIFF
--- a/test/helpers/AssertionsCustomTypes.sol
+++ b/test/helpers/AssertionsCustomTypes.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.0;
 
-import "src/EVault/shared/types/Types.sol";
+import "../../src/EVault/shared/types/Types.sol";
 import "forge-std/StdAssertions.sol";
 
 /// @notice assertion helpers for custom types

--- a/test/invariant/SimpleCriticalChecks.t.sol
+++ b/test/invariant/SimpleCriticalChecks.t.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.0;
 import {Test} from "forge-std/Test.sol";
 import {IEVC} from "ethereum-vault-connector/interfaces/IEthereumVaultConnector.sol";
 import {EVaultTestBase} from "../unit/evault/EVaultTestBase.t.sol";
-import {IEVault} from "src/EVault/IEVault.sol";
+import {IEVault} from "../../src/EVault/IEVault.sol";
 import {IRMTestDefault} from "../mocks/IRMTestDefault.sol";
 import {MockPriceOracle} from "../mocks/MockPriceOracle.sol";
 import "forge-std/console.sol";

--- a/test/invariants/CryticToFoundry.t.sol
+++ b/test/invariants/CryticToFoundry.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.19;
 // Libraries
 import "forge-std/Test.sol";
 import "forge-std/console.sol";
-import {Errors} from "src/EVault/shared/Errors.sol";
+import {Errors} from "../../src/EVault/shared/Errors.sol";
 
 // Test Contracts
 import {Invariants} from "./Invariants.t.sol";

--- a/test/invariants/Setup.t.sol
+++ b/test/invariants/Setup.t.sol
@@ -3,25 +3,25 @@ pragma solidity ^0.8.19;
 
 // Libraries
 import {EthereumVaultConnector} from "ethereum-vault-connector/EthereumVaultConnector.sol";
-import {DeployPermit2} from "test/invariants/utils/DeployPermit2.sol";
+import {DeployPermit2} from "./utils/DeployPermit2.sol";
 
 // Contracts
-import {GenericFactory} from "src/GenericFactory/GenericFactory.sol";
-import {EVault} from "src/EVault/EVault.sol";
-import {ProtocolConfig} from "src/ProtocolConfig/ProtocolConfig.sol";
+import {GenericFactory} from "../../src/GenericFactory/GenericFactory.sol";
+import {EVault} from "../../src/EVault/EVault.sol";
+import {ProtocolConfig} from "../../src/ProtocolConfig/ProtocolConfig.sol";
 import {IRMTestDefault} from "../mocks/IRMTestDefault.sol";
-import {Base} from "src/EVault/shared/Base.sol";
-import {Dispatch} from "src/EVault/Dispatch.sol";
+import {Base} from "../../src/EVault/shared/Base.sol";
+import {Dispatch} from "../../src/EVault/Dispatch.sol";
 
 // Modules
-import {Initialize} from "src/EVault/modules/Initialize.sol";
-import {Token} from "src/EVault/modules/Token.sol";
-import {Vault} from "src/EVault/modules/Vault.sol";
-import {Borrowing} from "src/EVault/modules/Borrowing.sol";
-import {Liquidation} from "src/EVault/modules/Liquidation.sol";
-import {BalanceForwarder} from "src/EVault/modules/BalanceForwarder.sol";
-import {Governance} from "src/EVault/modules/Governance.sol";
-import {RiskManager} from "src/EVault/modules/RiskManager.sol";
+import {Initialize} from "../../src/EVault/modules/Initialize.sol";
+import {Token} from "../../src/EVault/modules/Token.sol";
+import {Vault} from "../../src/EVault/modules/Vault.sol";
+import {Borrowing} from "../../src/EVault/modules/Borrowing.sol";
+import {Liquidation} from "../../src/EVault/modules/Liquidation.sol";
+import {BalanceForwarder} from "../../src/EVault/modules/BalanceForwarder.sol";
+import {Governance} from "../../src/EVault/modules/Governance.sol";
+import {RiskManager} from "../../src/EVault/modules/RiskManager.sol";
 
 // Test Contracts
 import {ERC20Mock as TestERC20} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
@@ -29,7 +29,7 @@ import {MockBalanceTracker} from "../mocks/MockBalanceTracker.sol";
 import {MockPriceOracle} from "../mocks/MockPriceOracle.sol";
 import {Actor} from "./utils/Actor.sol";
 import {BaseTest} from "./base/BaseTest.t.sol";
-import {EVaultExtended} from "test/invariants/helpers/extended/EVaultExtended.sol";
+import {EVaultExtended} from "./helpers/extended/EVaultExtended.sol";
 
 /// @title Setup
 /// @notice Setup contract for the invariant test Suite, inherited by Tester

--- a/test/invariants/base/BaseHandler.t.sol
+++ b/test/invariants/base/BaseHandler.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.19;
 // Libraries
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {TestERC20} from "test/mocks/TestERC20.sol";
+import {TestERC20} from "../../mocks/TestERC20.sol";
 
 // Contracts
 import {Actor} from "../utils/Actor.sol";

--- a/test/invariants/base/BaseStorage.t.sol
+++ b/test/invariants/base/BaseStorage.t.sol
@@ -3,8 +3,8 @@ pragma solidity ^0.8.19;
 
 // Contracts
 import {EthereumVaultConnector} from "ethereum-vault-connector/EthereumVaultConnector.sol";
-import {ProtocolConfig} from "src/ProtocolConfig/ProtocolConfig.sol";
-import "src/EVault/shared/Constants.sol";
+import {ProtocolConfig} from "../../../src/ProtocolConfig/ProtocolConfig.sol";
+import "../../../src/EVault/shared/Constants.sol";
 
 // Mock Contracts
 import {ERC20Mock as TestERC20} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";

--- a/test/invariants/base/ProtocolAssertions.t.sol
+++ b/test/invariants/base/ProtocolAssertions.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.19;
 
 // Base
 import {BaseTest} from "./BaseTest.t.sol";
-import {StdAsserts} from "test/invariants/utils/StdAsserts.sol";
+import {StdAsserts} from "../utils/StdAsserts.sol";
 
 /// @title ProtocolAssertions
 /// @notice Helper contract for protocol specific assertions

--- a/test/invariants/handlers/modules/BalanceForwarderModuleHandler.t.sol
+++ b/test/invariants/handlers/modules/BalanceForwarderModuleHandler.t.sol
@@ -6,7 +6,7 @@ import {Actor} from "../../utils/Actor.sol";
 import {BaseHandler} from "../../base/BaseHandler.t.sol";
 
 // Interfaces
-import {IBalanceForwarder} from "src/EVault/IEVault.sol";
+import {IBalanceForwarder} from "../../../../src/EVault/IEVault.sol";
 
 /// @title BalanceForwarderModuleHandler
 /// @notice Handler test contract for the risk balance forwarder module actions

--- a/test/invariants/handlers/modules/BorrowingModuleHandler.t.sol
+++ b/test/invariants/handlers/modules/BorrowingModuleHandler.t.sol
@@ -9,7 +9,7 @@ import {Actor} from "../../utils/Actor.sol";
 import {BaseHandler} from "../../base/BaseHandler.t.sol";
 
 // Interfaces
-import {IBorrowing, IERC4626} from "src/EVault/IEVault.sol";
+import {IBorrowing, IERC4626} from "../../../../src/EVault/IEVault.sol";
 
 /// @title BorrowingModuleHandler
 /// @notice Handler test contract for the BorrowingModule actions

--- a/test/invariants/handlers/modules/GovernanceModuleHandler.t.sol
+++ b/test/invariants/handlers/modules/GovernanceModuleHandler.t.sol
@@ -9,7 +9,7 @@ import {Actor} from "../../utils/Actor.sol";
 import {BaseHandler} from "../../base/BaseHandler.t.sol";
 
 // Interfaces
-import {IGovernance} from "src/EVault/IEVault.sol";
+import {IGovernance} from "../../../../src/EVault/IEVault.sol";
 
 /// @title GovernanceModuleHandler
 /// @notice Handler test contract for the governance module actions

--- a/test/invariants/handlers/modules/LiquidationModuleHandler.t.sol
+++ b/test/invariants/handlers/modules/LiquidationModuleHandler.t.sol
@@ -6,7 +6,7 @@ import {Actor} from "../../utils/Actor.sol";
 import {BaseHandler} from "../../base/BaseHandler.t.sol";
 
 // Interfaces
-import {ILiquidation} from "src/EVault/IEVault.sol";
+import {ILiquidation} from "../../../../src/EVault/IEVault.sol";
 
 /// @title LiquidationModuleHandler
 /// @notice Handler test contract for the VaultRegularBorrowable actions

--- a/test/invariants/handlers/modules/RiskManagerModuleHandler.t.sol
+++ b/test/invariants/handlers/modules/RiskManagerModuleHandler.t.sol
@@ -6,7 +6,7 @@ import {Actor} from "../../utils/Actor.sol";
 import {BaseHandler} from "../../base/BaseHandler.t.sol";
 
 // Interfaces
-import {IRiskManager} from "src/EVault/IEVault.sol";
+import {IRiskManager} from "../../../../src/EVault/IEVault.sol";
 
 /// @title RiskManagerModuleHandler
 /// @notice Handler test contract for the risk manager module actions

--- a/test/invariants/handlers/modules/TokenModuleHandler.t.sol
+++ b/test/invariants/handlers/modules/TokenModuleHandler.t.sol
@@ -6,7 +6,7 @@ import {Actor} from "../../utils/Actor.sol";
 import {BaseHandler} from "../../base/BaseHandler.t.sol";
 
 // Interfaces
-import {IERC20} from "src/EVault/IEVault.sol";
+import {IERC20} from "../../../../src/EVault/IEVault.sol";
 
 /// @title  TokenModuleHandler
 /// @notice Handler test contract for ERC20 contacts

--- a/test/invariants/handlers/modules/VaultModuleHandler.t.sol
+++ b/test/invariants/handlers/modules/VaultModuleHandler.t.sol
@@ -9,7 +9,7 @@ import {Actor} from "../../utils/Actor.sol";
 import {BaseHandler} from "../../base/BaseHandler.t.sol";
 
 // Interfaces
-import {IERC4626} from "src/EVault/IEVault.sol";
+import {IERC4626} from "../../../../src/EVault/IEVault.sol";
 
 /// @title VaultModuleHandler
 /// @notice Handler test contract for the generic ERC4626 vault actions

--- a/test/invariants/helpers/extended/EVaultExtended.sol
+++ b/test/invariants/helpers/extended/EVaultExtended.sol
@@ -2,10 +2,10 @@
 pragma solidity ^0.8.0;
 
 // Contracts
-import {EVault} from "src/EVault/EVault.sol";
+import {EVault} from "../../../../src/EVault/EVault.sol";
 
 // Types
-import {Snapshot} from "src/EVault/shared/types/Types.sol";
+import {Snapshot} from "../../../../src/EVault/shared/types/Types.sol";
 
 contract EVaultExtended is EVault {
     constructor(Integrations memory integrations, DeployedModules memory modules) EVault(integrations, modules) {}

--- a/test/invariants/hooks/BorrowingBeforeAfterHooks.t.sol
+++ b/test/invariants/hooks/BorrowingBeforeAfterHooks.t.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.19;
 
 // Contracts
-import "src/EVault/shared/types/Types.sol";
-import "src/EVault/shared/types/AmountCap.sol";
+import "../../../src/EVault/shared/types/Types.sol";
+import "../../../src/EVault/shared/types/AmountCap.sol";
 
 // Test Helpers
 import {Pretty, Strings} from "../utils/Pretty.sol";

--- a/test/invariants/hooks/VaultBeforeAfterHooks.t.sol
+++ b/test/invariants/hooks/VaultBeforeAfterHooks.t.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.19;
 
 // Contracts
-import "src/EVault/shared/types/Types.sol";
-import "src/EVault/shared/types/AmountCap.sol";
+import "../../../src/EVault/shared/types/Types.sol";
+import "../../../src/EVault/shared/types/AmountCap.sol";
 
 // Test Helpers
 import {Pretty, Strings} from "../utils/Pretty.sol";

--- a/test/invariants/invariants/BaseInvariants.t.sol
+++ b/test/invariants/invariants/BaseInvariants.t.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.19;
 import {HandlerAggregator} from "../HandlerAggregator.t.sol";
 
 // Types
-import {Snapshot, Assets} from "src/EVault/shared/types/Types.sol";
+import {Snapshot, Assets} from "../../../src/EVault/shared/types/Types.sol";
 
 /// @title BaseInvariants
 /// @notice Implements Invariants for the protocol

--- a/test/invariants/invariants/BorrowingModuleInvariants.t.sol
+++ b/test/invariants/invariants/BorrowingModuleInvariants.t.sol
@@ -6,7 +6,7 @@ import "forge-std/console.sol";
 
 // Contracts
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "src/EVault/shared/Constants.sol";
+import "../../../src/EVault/shared/Constants.sol";
 
 // Base Contracts
 import {HandlerAggregator} from "../HandlerAggregator.t.sol";

--- a/test/invariants/invariants/InterestInvariants.t.sol
+++ b/test/invariants/invariants/InterestInvariants.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.19;
 
 // Contracts
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "src/EVault/shared/Constants.sol";
+import "../../../src/EVault/shared/Constants.sol";
 
 // Base Contracts
 import {HandlerAggregator} from "../HandlerAggregator.t.sol";

--- a/test/mocks/IRMTestLinear.sol
+++ b/test/mocks/IRMTestLinear.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.0;
 
-import "src/InterestRateModels/IIRM.sol";
-import "src/EVault/shared/Constants.sol";
+import "../../src/InterestRateModels/IIRM.sol";
+import "../../src/EVault/shared/Constants.sol";
 
 contract IRMTestLinear is IIRM {
     uint256 internal constant MAX_IR = uint256(1e27 * 0.1) / SECONDS_PER_YEAR;

--- a/test/mocks/MockPriceOracle.sol
+++ b/test/mocks/MockPriceOracle.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.0;
 
-import "src/EVault/IEVault.sol";
+import "../../src/EVault/IEVault.sol";
 
 contract MockPriceOracle {
     error PO_BaseUnsupported();

--- a/test/unit/evault/DToken.t.sol
+++ b/test/unit/evault/DToken.t.sol
@@ -2,10 +2,10 @@
 
 pragma solidity ^0.8.0;
 
-import "test/unit/evault/EVaultTestBase.t.sol";
-import {DToken} from "src/EVault/DToken.sol";
-import {Errors} from "src/EVault/shared/Errors.sol";
-import {Events} from "src/EVault/shared/Events.sol";
+import "./EVaultTestBase.t.sol";
+import {DToken} from "../../../src/EVault/DToken.sol";
+import {Errors} from "../../../src/EVault/shared/Errors.sol";
+import {Events} from "../../../src/EVault/shared/Events.sol";
 
 contract DTokenTest is EVaultTestBase {
     address user = makeAddr("user");

--- a/test/unit/evault/Dispatch.t.sol
+++ b/test/unit/evault/Dispatch.t.sol
@@ -3,8 +3,8 @@
 pragma solidity ^0.8.0;
 
 import "./EVaultTestBase.t.sol";
-import {Errors} from "src/EVault/shared/Errors.sol";
-import {EVault} from "src/EVault/EVault.sol";
+import {Errors} from "../../../src/EVault/shared/Errors.sol";
+import {EVault} from "../../../src/EVault/EVault.sol";
 
 contract DispatchTest is EVaultTestBase {
     function test_Dispatch_moduleGetters() public view {

--- a/test/unit/evault/EVaultTestBase.t.sol
+++ b/test/unit/evault/EVaultTestBase.t.sol
@@ -4,28 +4,28 @@ pragma solidity ^0.8.13;
 import {Test, console2, stdError} from "forge-std/Test.sol";
 import {DeployPermit2} from "permit2/test/utils/DeployPermit2.sol";
 
-import {GenericFactory} from "src/GenericFactory/GenericFactory.sol";
+import {GenericFactory} from "../../../src/GenericFactory/GenericFactory.sol";
 
-import {EVault} from "src/EVault/EVault.sol";
-import {ProtocolConfig} from "src/ProtocolConfig/ProtocolConfig.sol";
+import {EVault} from "../../../src/EVault/EVault.sol";
+import {ProtocolConfig} from "../../../src/ProtocolConfig/ProtocolConfig.sol";
 
-import {Dispatch} from "src/EVault/Dispatch.sol";
+import {Dispatch} from "../../../src/EVault/Dispatch.sol";
 
-import {Initialize} from "src/EVault/modules/Initialize.sol";
-import {Token} from "src/EVault/modules/Token.sol";
-import {Vault} from "src/EVault/modules/Vault.sol";
-import {Borrowing} from "src/EVault/modules/Borrowing.sol";
-import {Liquidation} from "src/EVault/modules/Liquidation.sol";
-import {BalanceForwarder} from "src/EVault/modules/BalanceForwarder.sol";
-import {Governance} from "src/EVault/modules/Governance.sol";
-import {RiskManager} from "src/EVault/modules/RiskManager.sol";
+import {Initialize} from "../../../src/EVault/modules/Initialize.sol";
+import {Token} from "../../../src/EVault/modules/Token.sol";
+import {Vault} from "../../../src/EVault/modules/Vault.sol";
+import {Borrowing} from "../../../src/EVault/modules/Borrowing.sol";
+import {Liquidation} from "../../../src/EVault/modules/Liquidation.sol";
+import {BalanceForwarder} from "../../../src/EVault/modules/BalanceForwarder.sol";
+import {Governance} from "../../../src/EVault/modules/Governance.sol";
+import {RiskManager} from "../../../src/EVault/modules/RiskManager.sol";
 
-import {IEVault, IERC20} from "src/EVault/IEVault.sol";
-import {TypesLib} from "src/EVault/shared/types/Types.sol";
-import {Base} from "src/EVault/shared/Base.sol";
+import {IEVault, IERC20} from "../../../src/EVault/IEVault.sol";
+import {TypesLib} from "../../../src/EVault/shared/types/Types.sol";
+import {Base} from "../../../src/EVault/shared/Base.sol";
 
-import {Core} from "src/ProductLines/Core.sol";
-import {Escrow} from "src/ProductLines/Escrow.sol";
+import {Core} from "../../../src/ProductLines/Core.sol";
+import {Escrow} from "../../../src/ProductLines/Escrow.sol";
 
 import {EthereumVaultConnector} from "ethereum-vault-connector/EthereumVaultConnector.sol";
 
@@ -33,12 +33,12 @@ import {TestERC20} from "../../mocks/TestERC20.sol";
 import {MockBalanceTracker} from "../../mocks/MockBalanceTracker.sol";
 import {MockPriceOracle} from "../../mocks/MockPriceOracle.sol";
 import {IRMTestDefault} from "../../mocks/IRMTestDefault.sol";
-import {IHookTarget} from "src/interfaces/IHookTarget.sol";
+import {IHookTarget} from "../../../src/interfaces/IHookTarget.sol";
 
 import {AssertionsCustomTypes} from "../../helpers/AssertionsCustomTypes.sol";
 import "./InvariantOverrides.sol";
 
-import "src/EVault/shared/Constants.sol";
+import "../../../src/EVault/shared/Constants.sol";
 
 contract EVaultTestBase is AssertionsCustomTypes, Test, DeployPermit2 {
     EthereumVaultConnector public evc;

--- a/test/unit/evault/InvariantOverrides.sol
+++ b/test/unit/evault/InvariantOverrides.sol
@@ -2,15 +2,15 @@
 
 pragma solidity ^0.8.0;
 
-import {EVault} from "src/EVault/EVault.sol";
-import "src/EVault/modules/BalanceForwarder.sol";
-import "src/EVault/modules/Borrowing.sol";
-import "src/EVault/modules/Governance.sol";
-import "src/EVault/modules/Initialize.sol";
-import "src/EVault/modules/Liquidation.sol";
-import "src/EVault/modules/RiskManager.sol";
-import "src/EVault/modules/Token.sol";
-import "src/EVault/modules/Vault.sol";
+import {EVault} from "../../../src/EVault/EVault.sol";
+import "../../../src/EVault/modules/BalanceForwarder.sol";
+import "../../../src/EVault/modules/Borrowing.sol";
+import "../../../src/EVault/modules/Governance.sol";
+import "../../../src/EVault/modules/Initialize.sol";
+import "../../../src/EVault/modules/Liquidation.sol";
+import "../../../src/EVault/modules/RiskManager.sol";
+import "../../../src/EVault/modules/Token.sol";
+import "../../../src/EVault/modules/Vault.sol";
 import "forge-std/console.sol";
 
 // Abstract contract to override functions and check invariants.

--- a/test/unit/evault/modules/BalanceForwarder/control.t.sol
+++ b/test/unit/evault/modules/BalanceForwarder/control.t.sol
@@ -2,9 +2,9 @@
 
 pragma solidity ^0.8.0;
 
-import "test/unit/evault/EVaultTestBase.t.sol";
-import {Errors} from "src/EVault/shared/Errors.sol";
-import {Events} from "src/EVault/shared/Events.sol";
+import "../../EVaultTestBase.t.sol";
+import {Errors} from "../../../../../src/EVault/shared/Errors.sol";
+import {Events} from "../../../../../src/EVault/shared/Events.sol";
 import "forge-std/Test.sol";
 
 contract BalanceForwarderTest_Control is EVaultTestBase {

--- a/test/unit/evault/modules/BalanceForwarder/hooks.t.sol
+++ b/test/unit/evault/modules/BalanceForwarder/hooks.t.sol
@@ -2,10 +2,10 @@
 
 pragma solidity ^0.8.0;
 
-import "test/unit/evault/EVaultTestBase.t.sol";
-import {Errors} from "src/EVault/shared/Errors.sol";
-import {Events} from "src/EVault/shared/Events.sol";
-import {ConfigAmountLib} from "src/EVault/shared/types/ConfigAmount.sol";
+import "../../EVaultTestBase.t.sol";
+import {Errors} from "../../../../../src/EVault/shared/Errors.sol";
+import {Events} from "../../../../../src/EVault/shared/Events.sol";
+import {ConfigAmountLib} from "../../../../../src/EVault/shared/types/ConfigAmount.sol";
 
 contract BalanceForwarderTest_Hooks is EVaultTestBase {
     address alice = makeAddr("alice");

--- a/test/unit/evault/modules/Governance/hookedOps.t.sol
+++ b/test/unit/evault/modules/Governance/hookedOps.t.sol
@@ -2,10 +2,10 @@
 
 pragma solidity ^0.8.0;
 
-import {EVaultTestBase, EthereumVaultConnector, IEVault} from "test/unit/evault/EVaultTestBase.t.sol";
-import {Errors} from "src/EVault/shared/Errors.sol";
-import {IHookTarget} from "src/interfaces/IHookTarget.sol";
-import "src/EVault/shared/Constants.sol";
+import {EVaultTestBase, EthereumVaultConnector, IEVault} from "../../EVaultTestBase.t.sol";
+import {Errors} from "../../../../../src/EVault/shared/Errors.sol";
+import {IHookTarget} from "../../../../../src/interfaces/IHookTarget.sol";
+import "../../../../../src/EVault/shared/Constants.sol";
 
 contract MockHookTarget is IHookTarget {
     bytes32 internal expectedDataHash;

--- a/test/unit/evault/modules/Governance/interestFee.t.sol
+++ b/test/unit/evault/modules/Governance/interestFee.t.sol
@@ -3,9 +3,9 @@
 pragma solidity ^0.8.0;
 
 import {EVaultTestBase} from "../../EVaultTestBase.t.sol";
-import {GovernanceModule} from "src/EVault/modules/Governance.sol";
+import {GovernanceModule} from "../../../../../src/EVault/modules/Governance.sol";
 
-import "src/EVault/shared/types/Types.sol";
+import "../../../../../src/EVault/shared/types/Types.sol";
 
 contract GovernanceTest_InterestFee is EVaultTestBase {
     using TypesLib for uint256;

--- a/test/unit/evault/modules/Governance/pause.t.sol
+++ b/test/unit/evault/modules/Governance/pause.t.sol
@@ -2,11 +2,11 @@
 
 pragma solidity ^0.8.0;
 
-import {EVaultTestBase, EthereumVaultConnector, IEVault} from "test/unit/evault/EVaultTestBase.t.sol";
-import {Errors} from "src/EVault/shared/Errors.sol";
-import "src/EVault/shared/Constants.sol";
-import "src/EVault/shared/types/Types.sol";
-import "src/EVault/shared/Events.sol";
+import {EVaultTestBase, EthereumVaultConnector, IEVault} from "../../EVaultTestBase.t.sol";
+import {Errors} from "../../../../../src/EVault/shared/Errors.sol";
+import "../../../../../src/EVault/shared/Constants.sol";
+import "../../../../../src/EVault/shared/types/Types.sol";
+import "../../../../../src/EVault/shared/Events.sol";
 import "forge-std/Vm.sol";
 
 contract Governance_PauseOps is EVaultTestBase {

--- a/test/unit/evault/modules/Governance/reserves.t.sol
+++ b/test/unit/evault/modules/Governance/reserves.t.sol
@@ -2,9 +2,9 @@
 
 pragma solidity ^0.8.0;
 
-import {EVaultTestBase} from "test/unit/evault/EVaultTestBase.t.sol";
-import {Events} from "src/EVault/shared/Events.sol";
-import {Errors} from "src/EVault/shared/Errors.sol";
+import {EVaultTestBase} from "../../EVaultTestBase.t.sol";
+import {Events} from "../../../../../src/EVault/shared/Events.sol";
+import {Errors} from "../../../../../src/EVault/shared/Errors.sol";
 import {IRMTestFixed} from "../../../../mocks/IRMTestFixed.sol";
 
 contract Governance_Reserves is EVaultTestBase {

--- a/test/unit/evault/modules/Governance/setName.t.sol
+++ b/test/unit/evault/modules/Governance/setName.t.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.0;
 
-import {EVaultTestBase} from "test/unit/evault/EVaultTestBase.t.sol";
-import {Errors} from "src/EVault/shared/Errors.sol";
+import {EVaultTestBase} from "../../EVaultTestBase.t.sol";
+import {Errors} from "../../../../../src/EVault/shared/Errors.sol";
 
 contract Governance_SetName is EVaultTestBase {
     address notGovernor;

--- a/test/unit/evault/modules/Governance/setSymbol.t.sol
+++ b/test/unit/evault/modules/Governance/setSymbol.t.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.0;
 
-import {EVaultTestBase} from "test/unit/evault/EVaultTestBase.t.sol";
-import {Errors} from "src/EVault/shared/Errors.sol";
+import {EVaultTestBase} from "../../EVaultTestBase.t.sol";
+import {Errors} from "../../../../../src/EVault/shared/Errors.sol";
 
 contract Governance_SetSymbol is EVaultTestBase {
     address notGovernor;

--- a/test/unit/evault/modules/Governance/views.t.sol
+++ b/test/unit/evault/modules/Governance/views.t.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.0;
 
-import {EVaultTestBase} from "test/unit/evault/EVaultTestBase.t.sol";
+import {EVaultTestBase} from "../../EVaultTestBase.t.sol";
 
 contract Governance_views is EVaultTestBase {
     function test_protocolFeeShare() public {

--- a/test/unit/evault/modules/Initialize/errors.t.sol
+++ b/test/unit/evault/modules/Initialize/errors.t.sol
@@ -2,11 +2,11 @@
 
 pragma solidity ^0.8.0;
 
-import "test/unit/evault/EVaultTestBase.t.sol";
-import {Errors} from "src/EVault/shared/Errors.sol";
-import {Events} from "src/EVault/shared/Events.sol";
-import {IComponent} from "src/GenericFactory/GenericFactory.sol";
-import {MetaProxyDeployer} from "src/GenericFactory/MetaProxyDeployer.sol";
+import "../../EVaultTestBase.t.sol";
+import {Errors} from "../../../../../src/EVault/shared/Errors.sol";
+import {Events} from "../../../../../src/EVault/shared/Events.sol";
+import {IComponent} from "../../../../../src/GenericFactory/GenericFactory.sol";
+import {MetaProxyDeployer} from "../../../../../src/GenericFactory/MetaProxyDeployer.sol";
 
 contract InitializeTests is EVaultTestBase, MetaProxyDeployer {
     function test_cant_reinitialize() public {

--- a/test/unit/evault/modules/Liquidation/basic.t.sol
+++ b/test/unit/evault/modules/Liquidation/basic.t.sol
@@ -3,14 +3,14 @@
 pragma solidity ^0.8.0;
 
 import {EVaultTestBase} from "../../EVaultTestBase.t.sol";
-import {Events} from "src/EVault/shared/Events.sol";
-import {SafeERC20Lib} from "src/EVault/shared/lib/SafeERC20Lib.sol";
+import {Events} from "../../../../../src/EVault/shared/Events.sol";
+import {SafeERC20Lib} from "../../../../../src/EVault/shared/lib/SafeERC20Lib.sol";
 import {IAllowanceTransfer} from "permit2/src/interfaces/IAllowanceTransfer.sol";
 
 import {console} from "forge-std/Test.sol";
 
-import "src/EVault/shared/types/Types.sol";
-import "src/EVault/shared/Constants.sol";
+import "../../../../../src/EVault/shared/types/Types.sol";
+import "../../../../../src/EVault/shared/Constants.sol";
 
 contract LiquidationUnitTest is EVaultTestBase {
     using TypesLib for uint256;

--- a/test/unit/evault/modules/Liquidation/full.t.sol
+++ b/test/unit/evault/modules/Liquidation/full.t.sol
@@ -4,9 +4,9 @@ pragma solidity ^0.8.0;
 
 import {EVaultTestBase} from "../../EVaultTestBase.t.sol";
 
-import {Events} from "src/EVault/shared/Events.sol";
-import {Errors} from "src/EVault/shared/Errors.sol";
-import {IEVault} from "src/EVault/IEVault.sol";
+import {Events} from "../../../../../src/EVault/shared/Events.sol";
+import {Errors} from "../../../../../src/EVault/shared/Errors.sol";
+import {IEVault} from "../../../../../src/EVault/IEVault.sol";
 import {IEVC} from "ethereum-vault-connector/interfaces/IEthereumVaultConnector.sol";
 import {TestERC20} from "../../../../mocks/TestERC20.sol";
 import {IRMTestFixed} from "../../../../mocks/IRMTestFixed.sol";

--- a/test/unit/evault/modules/Token/actions.t.sol
+++ b/test/unit/evault/modules/Token/actions.t.sol
@@ -2,11 +2,11 @@
 
 pragma solidity ^0.8.0;
 
-import "test/unit/evault/EVaultTestBase.t.sol";
+import "../../EVaultTestBase.t.sol";
 import {Errors as EVCErrors} from "ethereum-vault-connector/Errors.sol";
 import {IEVC} from "ethereum-vault-connector/interfaces/IEthereumVaultConnector.sol";
-import {Errors} from "src/EVault/shared/Errors.sol";
-import {Events} from "src/EVault/shared/Events.sol";
+import {Errors} from "../../../../../src/EVault/shared/Errors.sol";
+import {Events} from "../../../../../src/EVault/shared/Events.sol";
 
 contract ERC20Test_Actions is EVaultTestBase {
     address alice = makeAddr("alice");

--- a/test/unit/evault/modules/Vault/amountLimits.t.sol
+++ b/test/unit/evault/modules/Vault/amountLimits.t.sol
@@ -3,10 +3,10 @@
 pragma solidity ^0.8.0;
 
 import {EVaultTestBase} from "../../EVaultTestBase.t.sol";
-import {Errors} from "src/EVault/shared/Errors.sol";
-import {IEVault} from "src/EVault/IEVault.sol";
+import {Errors} from "../../../../../src/EVault/shared/Errors.sol";
+import {IEVault} from "../../../../../src/EVault/IEVault.sol";
 import {TestERC20} from "../../../../mocks/TestERC20.sol";
-import "src/EVault/shared/types/Types.sol";
+import "../../../../../src/EVault/shared/types/Types.sol";
 
 contract VaultTest_AmountLimits is EVaultTestBase {
     address user1;

--- a/test/unit/evault/modules/Vault/balancesNoInterest.t.sol
+++ b/test/unit/evault/modules/Vault/balancesNoInterest.t.sol
@@ -3,9 +3,9 @@
 pragma solidity ^0.8.0;
 
 import {EVaultTestBase} from "../../EVaultTestBase.t.sol";
-import {Errors} from "src/EVault/shared/Errors.sol";
-import {Events} from "src/EVault/shared/Events.sol";
-import {SafeERC20Lib} from "src/EVault/shared/lib/SafeERC20Lib.sol";
+import {Errors} from "../../../../../src/EVault/shared/Errors.sol";
+import {Events} from "../../../../../src/EVault/shared/Events.sol";
+import {SafeERC20Lib} from "../../../../../src/EVault/shared/lib/SafeERC20Lib.sol";
 import {IAllowanceTransfer} from "permit2/src/interfaces/IAllowanceTransfer.sol";
 
 contract VaultTest_BalancesNoInterest is EVaultTestBase {

--- a/test/unit/evault/modules/Vault/balancesWithInterest.t.sol
+++ b/test/unit/evault/modules/Vault/balancesWithInterest.t.sol
@@ -3,14 +3,14 @@
 pragma solidity ^0.8.0;
 
 import {EVaultTestBase} from "../../EVaultTestBase.t.sol";
-import {Errors} from "src/EVault/shared/Errors.sol";
-import {Events} from "src/EVault/shared/Events.sol";
-import {SafeERC20Lib} from "src/EVault/shared/lib/SafeERC20Lib.sol";
+import {Errors} from "../../../../../src/EVault/shared/Errors.sol";
+import {Events} from "../../../../../src/EVault/shared/Events.sol";
+import {SafeERC20Lib} from "../../../../../src/EVault/shared/lib/SafeERC20Lib.sol";
 import {IAllowanceTransfer} from "permit2/src/interfaces/IAllowanceTransfer.sol";
 import {IRMTestFixed} from "../../../../mocks/IRMTestFixed.sol";
 import {IRMTestZero} from "../../../../mocks/IRMTestZero.sol";
-import {RPow} from "src/EVault/shared/lib/RPow.sol";
-import {IEVault} from "src/EVault/IEVault.sol";
+import {RPow} from "../../../../../src/EVault/shared/lib/RPow.sol";
+import {IEVault} from "../../../../../src/EVault/IEVault.sol";
 
 contract VaultTest_BalancesWithInterest is EVaultTestBase {
     uint256 SECONDS_PER_YEAR = 365.2425 days;

--- a/test/unit/evault/modules/Vault/batch.t.sol
+++ b/test/unit/evault/modules/Vault/batch.t.sol
@@ -3,12 +3,12 @@
 pragma solidity ^0.8.0;
 
 import {EVaultTestBase} from "../../EVaultTestBase.t.sol";
-import {Errors} from "src/EVault/shared/Errors.sol";
-import {IEVault} from "src/EVault/IEVault.sol";
+import {Errors} from "../../../../../src/EVault/shared/Errors.sol";
+import {IEVault} from "../../../../../src/EVault/IEVault.sol";
 import {IEVC} from "ethereum-vault-connector/interfaces/IEthereumVaultConnector.sol";
 import {TestERC20} from "../../../../mocks/TestERC20.sol";
 import {IRMTestZero} from "../../../../mocks/IRMTestZero.sol";
-import "src/EVault/shared/types/Types.sol";
+import "../../../../../src/EVault/shared/types/Types.sol";
 
 contract VaultTest_Batch is EVaultTestBase {
     address user1;

--- a/test/unit/evault/modules/Vault/borrow.t.sol
+++ b/test/unit/evault/modules/Vault/borrow.t.sol
@@ -3,8 +3,8 @@
 pragma solidity ^0.8.0;
 
 import {EVaultTestBase} from "../../EVaultTestBase.t.sol";
-import {Events} from "src/EVault/shared/Events.sol";
-import {SafeERC20Lib} from "src/EVault/shared/lib/SafeERC20Lib.sol";
+import {Events} from "../../../../../src/EVault/shared/Events.sol";
+import {SafeERC20Lib} from "../../../../../src/EVault/shared/lib/SafeERC20Lib.sol";
 import {IAllowanceTransfer} from "permit2/src/interfaces/IAllowanceTransfer.sol";
 import {IRMMax} from "../../../../mocks/IRMMax.sol";
 import {IRMTestFixed} from "../../../../mocks/IRMTestFixed.sol";

--- a/test/unit/evault/modules/Vault/borrowBasic.t.sol
+++ b/test/unit/evault/modules/Vault/borrowBasic.t.sol
@@ -5,9 +5,9 @@ pragma solidity ^0.8.0;
 import {EVaultTestBase} from "../../EVaultTestBase.t.sol";
 import {IRMTestZero} from "../../../../mocks/IRMTestZero.sol";
 import {IRMTestFixed} from "../../../../mocks/IRMTestFixed.sol";
-import {Errors} from "src/EVault/shared/Errors.sol";
-import {Events} from "src/EVault/shared/Events.sol";
-import "src/EVault/shared/types/Types.sol";
+import {Errors} from "../../../../../src/EVault/shared/Errors.sol";
+import {Events} from "../../../../../src/EVault/shared/Events.sol";
+import "../../../../../src/EVault/shared/types/Types.sol";
 
 contract VaultTest_BorrowBasic is EVaultTestBase {
     using TypesLib for uint256;

--- a/test/unit/evault/modules/Vault/borrowIsolation.t.sol
+++ b/test/unit/evault/modules/Vault/borrowIsolation.t.sol
@@ -3,13 +3,13 @@
 pragma solidity ^0.8.0;
 
 import {EVaultTestBase} from "../../EVaultTestBase.t.sol";
-import {Errors} from "src/EVault/shared/Errors.sol";
+import {Errors} from "../../../../../src/EVault/shared/Errors.sol";
 import {Errors as EVCErrors} from "ethereum-vault-connector/Errors.sol";
-import {IEVault} from "src/EVault/IEVault.sol";
+import {IEVault} from "../../../../../src/EVault/IEVault.sol";
 import {IEVC} from "ethereum-vault-connector/interfaces/IEthereumVaultConnector.sol";
 import {TestERC20} from "../../../../mocks/TestERC20.sol";
 import {IRMTestZero} from "../../../../mocks/IRMTestZero.sol";
-import "src/EVault/shared/types/Types.sol";
+import "../../../../../src/EVault/shared/types/Types.sol";
 
 contract VaultTest_BorrowIsolation is EVaultTestBase {
     address user1;

--- a/test/unit/evault/modules/Vault/caps.t.sol
+++ b/test/unit/evault/modules/Vault/caps.t.sol
@@ -2,16 +2,16 @@
 
 pragma solidity ^0.8.0;
 
-import {EVaultTestBase} from "test/unit/evault/EVaultTestBase.t.sol";
-import {Errors} from "src/EVault/shared/Errors.sol";
-import {GovernanceModule} from "src/EVault/modules/Governance.sol";
-import {Events} from "src/EVault/shared/Events.sol";
-import {IEVault} from "src/EVault/IEVault.sol";
+import {EVaultTestBase} from "../../EVaultTestBase.t.sol";
+import {Errors} from "../../../../../src/EVault/shared/Errors.sol";
+import {GovernanceModule} from "../../../../../src/EVault/modules/Governance.sol";
+import {Events} from "../../../../../src/EVault/shared/Events.sol";
+import {IEVault} from "../../../../../src/EVault/IEVault.sol";
 import {IEVC} from "ethereum-vault-connector/interfaces/IEthereumVaultConnector.sol";
 import {TestERC20} from "../../../../mocks/TestERC20.sol";
 import {IRMTestFixed} from "../../../../mocks/IRMTestFixed.sol";
 import {IRMTestZero} from "../../../../mocks/IRMTestZero.sol";
-import "src/EVault/shared/types/Types.sol";
+import "../../../../../src/EVault/shared/types/Types.sol";
 
 contract VaultTest_Caps is EVaultTestBase {
     using TypesLib for uint256;

--- a/test/unit/evault/modules/Vault/decimals.t.sol
+++ b/test/unit/evault/modules/Vault/decimals.t.sol
@@ -3,13 +3,13 @@
 pragma solidity ^0.8.0;
 
 import {EVaultTestBase} from "../../EVaultTestBase.t.sol";
-import {IEVault} from "src/EVault/IEVault.sol";
+import {IEVault} from "../../../../../src/EVault/IEVault.sol";
 import {TestERC20} from "../../../../mocks/TestERC20.sol";
 import {IRMTestFixed} from "../../../../mocks/IRMTestFixed.sol";
 import {IRMTestZero} from "../../../../mocks/IRMTestZero.sol";
 import {IRMTestLinear} from "../../../../mocks/IRMTestLinear.sol";
-import {DToken} from "src/EVault/DToken.sol";
-import "src/EVault/shared/types/Types.sol";
+import {DToken} from "../../../../../src/EVault/DToken.sol";
+import "../../../../../src/EVault/shared/types/Types.sol";
 
 contract VaultTest_Decimals is EVaultTestBase {
     address user1;

--- a/test/unit/evault/modules/Vault/deposit.t.sol
+++ b/test/unit/evault/modules/Vault/deposit.t.sol
@@ -3,13 +3,13 @@
 pragma solidity ^0.8.0;
 
 import {EVaultTestBase} from "../../EVaultTestBase.t.sol";
-import {Events} from "src/EVault/shared/Events.sol";
-import {SafeERC20Lib} from "src/EVault/shared/lib/SafeERC20Lib.sol";
+import {Events} from "../../../../../src/EVault/shared/Events.sol";
+import {SafeERC20Lib} from "../../../../../src/EVault/shared/lib/SafeERC20Lib.sol";
 import {Permit2ECDSASigner} from "../../../../mocks/Permit2ECDSASigner.sol";
 import {IAllowanceTransfer} from "permit2/src/interfaces/IAllowanceTransfer.sol";
 import {IEVC} from "ethereum-vault-connector/interfaces/IEthereumVaultConnector.sol";
 
-import "src/EVault/shared/types/Types.sol";
+import "../../../../../src/EVault/shared/types/Types.sol";
 
 contract VaultTest_Deposit is EVaultTestBase {
     using TypesLib for uint256;

--- a/test/unit/evault/modules/Vault/flashloan.t.sol
+++ b/test/unit/evault/modules/Vault/flashloan.t.sol
@@ -3,14 +3,14 @@
 pragma solidity ^0.8.0;
 
 import {EVaultTestBase, Test} from "../../EVaultTestBase.t.sol";
-import {Events} from "src/EVault/shared/Events.sol";
+import {Events} from "../../../../../src/EVault/shared/Events.sol";
 
 import {console2} from "forge-std/Test.sol";
 
 import {IEVault} from "../../EVaultTestBase.t.sol";
 
-import "src/EVault/shared/types/Types.sol";
-import "src/EVault/shared/Constants.sol";
+import "../../../../../src/EVault/shared/types/Types.sol";
+import "../../../../../src/EVault/shared/Constants.sol";
 
 // From Borrowing.sol
 /// @notice Definition of callback method that flashLoan will invoke on your contract

--- a/test/unit/evault/modules/Vault/liquidity.t.sol
+++ b/test/unit/evault/modules/Vault/liquidity.t.sol
@@ -3,14 +3,14 @@
 pragma solidity ^0.8.0;
 
 import {EVaultTestBase} from "../../EVaultTestBase.t.sol";
-import {Errors} from "src/EVault/shared/Errors.sol";
-import {Events} from "src/EVault/shared/Events.sol";
-import {IEVault} from "src/EVault/IEVault.sol";
+import {Errors} from "../../../../../src/EVault/shared/Errors.sol";
+import {Events} from "../../../../../src/EVault/shared/Events.sol";
+import {IEVault} from "../../../../../src/EVault/IEVault.sol";
 import {IEVC} from "ethereum-vault-connector/interfaces/IEthereumVaultConnector.sol";
 import {TestERC20} from "../../../../mocks/TestERC20.sol";
 import {IRMTestFixed} from "../../../../mocks/IRMTestFixed.sol";
 import {IRMTestZero} from "../../../../mocks/IRMTestZero.sol";
-import "src/EVault/shared/types/Types.sol";
+import "../../../../../src/EVault/shared/types/Types.sol";
 import {Errors as EVCErrors} from "ethereum-vault-connector/Errors.sol";
 
 contract VaultTest_Liquidity is EVaultTestBase {

--- a/test/unit/evault/modules/Vault/loopDeloop.t.sol
+++ b/test/unit/evault/modules/Vault/loopDeloop.t.sol
@@ -3,12 +3,12 @@
 pragma solidity ^0.8.0;
 
 import {EVaultTestBase} from "../../EVaultTestBase.t.sol";
-import {Errors} from "src/EVault/shared/Errors.sol";
-import {Events} from "src/EVault/shared/Events.sol";
-import {IEVault} from "src/EVault/IEVault.sol";
+import {Errors} from "../../../../../src/EVault/shared/Errors.sol";
+import {Events} from "../../../../../src/EVault/shared/Events.sol";
+import {IEVault} from "../../../../../src/EVault/IEVault.sol";
 import {TestERC20} from "../../../../mocks/TestERC20.sol";
 import {IRMTestZero} from "../../../../mocks/IRMTestZero.sol";
-import "src/EVault/shared/types/Types.sol";
+import "../../../../../src/EVault/shared/types/Types.sol";
 
 contract VaultTest_LoopDeloop is EVaultTestBase {
     address user1;

--- a/test/unit/evault/modules/Vault/maliciousToken.t.sol
+++ b/test/unit/evault/modules/Vault/maliciousToken.t.sol
@@ -3,9 +3,9 @@
 pragma solidity ^0.8.0;
 
 import {EVaultTestBase} from "../../EVaultTestBase.t.sol";
-import {Errors} from "src/EVault/shared/Errors.sol";
+import {Errors} from "../../../../../src/EVault/shared/Errors.sol";
 import {IRMTestLinear} from "../../../../mocks/IRMTestLinear.sol";
-import {SafeERC20Lib} from "src/EVault/shared/lib/SafeERC20Lib.sol";
+import {SafeERC20Lib} from "../../../../../src/EVault/shared/lib/SafeERC20Lib.sol";
 import {IAllowanceTransfer} from "permit2/src/interfaces/IAllowanceTransfer.sol";
 
 contract VaultTest_MaliciousToken is EVaultTestBase {

--- a/test/unit/evault/modules/Vault/nested.t.sol
+++ b/test/unit/evault/modules/Vault/nested.t.sol
@@ -3,16 +3,16 @@
 pragma solidity ^0.8.0;
 
 import {EVaultTestBase} from "../../EVaultTestBase.t.sol";
-import {Events} from "src/EVault/shared/Events.sol";
-import {SafeERC20Lib} from "src/EVault/shared/lib/SafeERC20Lib.sol";
+import {Events} from "../../../../../src/EVault/shared/Events.sol";
+import {SafeERC20Lib} from "../../../../../src/EVault/shared/lib/SafeERC20Lib.sol";
 import {IRMMax} from "../../../../mocks/IRMMax.sol";
 
 import {IEVault, IRMTestDefault} from "../../EVaultTestBase.t.sol";
 
 import "forge-std/console2.sol";
 
-import "src/EVault/shared/types/Types.sol";
-import "src/EVault/shared/Constants.sol";
+import "../../../../../src/EVault/shared/types/Types.sol";
+import "../../../../../src/EVault/shared/Constants.sol";
 
 contract VaultTest_Nested is EVaultTestBase {
     using TypesLib for uint256;

--- a/test/unit/evault/modules/Vault/pullDebt.t.sol
+++ b/test/unit/evault/modules/Vault/pullDebt.t.sol
@@ -3,9 +3,9 @@
 pragma solidity ^0.8.0;
 
 import {EVaultTestBase} from "../../EVaultTestBase.t.sol";
-import {Errors} from "src/EVault/shared/Errors.sol";
-import {Events} from "src/EVault/shared/Events.sol";
-import {IEVault} from "src/EVault/IEVault.sol";
+import {Errors} from "../../../../../src/EVault/shared/Errors.sol";
+import {Events} from "../../../../../src/EVault/shared/Events.sol";
+import {IEVault} from "../../../../../src/EVault/IEVault.sol";
 import {IEVC} from "ethereum-vault-connector/interfaces/IEthereumVaultConnector.sol";
 import {TestERC20} from "../../../../mocks/TestERC20.sol";
 import {IRMTestFixed} from "../../../../mocks/IRMTestFixed.sol";

--- a/test/unit/evault/modules/Vault/skim.t.sol
+++ b/test/unit/evault/modules/Vault/skim.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 
 import {EVaultTestBase} from "../../EVaultTestBase.t.sol";
 
-import "src/EVault/shared/types/Types.sol";
+import "../../../../../src/EVault/shared/types/Types.sol";
 
 contract VaultTest_Skim is EVaultTestBase {
     using TypesLib for uint256;

--- a/test/unit/evault/modules/Vault/transferShares.t.sol
+++ b/test/unit/evault/modules/Vault/transferShares.t.sol
@@ -3,8 +3,8 @@
 pragma solidity ^0.8.0;
 
 import {EVaultTestBase} from "../../EVaultTestBase.t.sol";
-import {Errors} from "src/EVault/shared/Errors.sol";
-import {Events} from "src/EVault/shared/Events.sol";
+import {Errors} from "../../../../../src/EVault/shared/Errors.sol";
+import {Events} from "../../../../../src/EVault/shared/Events.sol";
 import {IEVC} from "ethereum-vault-connector/interfaces/IEthereumVaultConnector.sol";
 
 //transfer eVault balances, without interest

--- a/test/unit/evault/modules/Vault/withdraw.t.sol
+++ b/test/unit/evault/modules/Vault/withdraw.t.sol
@@ -3,16 +3,16 @@
 pragma solidity ^0.8.0;
 
 import {EVaultTestBase} from "../../EVaultTestBase.t.sol";
-import {Events} from "src/EVault/shared/Events.sol";
-import {SafeERC20Lib} from "src/EVault/shared/lib/SafeERC20Lib.sol";
+import {Events} from "../../../../../src/EVault/shared/Events.sol";
+import {SafeERC20Lib} from "../../../../../src/EVault/shared/lib/SafeERC20Lib.sol";
 import {IAllowanceTransfer} from "permit2/src/interfaces/IAllowanceTransfer.sol";
-import {IEVault} from "src/EVault/IEVault.sol";
+import {IEVault} from "../../../../../src/EVault/IEVault.sol";
 import {TestERC20} from "../../../../mocks/TestERC20.sol";
 import {IRMTestZero} from "../../../../mocks/IRMTestZero.sol";
-import {Errors} from "src/EVault/shared/Errors.sol";
+import {Errors} from "../../../../../src/EVault/shared/Errors.sol";
 
-import "src/EVault/shared/types/Types.sol";
-import "src/EVault/shared/Constants.sol";
+import "../../../../../src/EVault/shared/types/Types.sol";
+import "../../../../../src/EVault/shared/Constants.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/unit/evault/protocolConfig.t.sol
+++ b/test/unit/evault/protocolConfig.t.sol
@@ -2,12 +2,12 @@
 
 pragma solidity ^0.8.0;
 
-import {EVaultTestBase, ProtocolConfig} from "test/unit/evault/EVaultTestBase.t.sol";
-import {Errors} from "src/EVault/shared/Errors.sol";
-import {GovernanceModule} from "src/EVault/modules/Governance.sol";
-import "src/EVault/modules/Governance.sol";
-import "src/EVault/shared/Constants.sol";
-import "src/EVault/shared/types/Types.sol";
+import {EVaultTestBase, ProtocolConfig} from "./EVaultTestBase.t.sol";
+import {Errors} from "../../../src/EVault/shared/Errors.sol";
+import {GovernanceModule} from "../../../src/EVault/modules/Governance.sol";
+import "../../../src/EVault/modules/Governance.sol";
+import "../../../src/EVault/shared/Constants.sol";
+import "../../../src/EVault/shared/types/Types.sol";
 
 uint16 constant DEFAULT_INTEREST_FEE = 0.1e4;
 

--- a/test/unit/evault/shared/AssetTransfers.t.sol
+++ b/test/unit/evault/shared/AssetTransfers.t.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.0;
 
-import "src/EVault/shared/AssetTransfers.sol";
-import "src/EVault/shared/Errors.sol";
+import "../../../../src/EVault/shared/AssetTransfers.sol";
+import "../../../../src/EVault/shared/Errors.sol";
 
 import "../EVaultTestBase.t.sol";
 

--- a/test/unit/evault/shared/EVCClient.t.sol
+++ b/test/unit/evault/shared/EVCClient.t.sol
@@ -11,8 +11,8 @@ import {
     IRMTestDefault,
     TestERC20
 } from "../EVaultTestBase.t.sol";
-import {EVCClient, IEVC} from "src/EVault/shared/EVCClient.sol";
-import "src/EVault/shared/types/Types.sol";
+import {EVCClient, IEVC} from "../../../../src/EVault/shared/EVCClient.sol";
+import "../../../../src/EVault/shared/types/Types.sol";
 import {stdError} from "forge-std/StdError.sol";
 
 contract EVCClientUnitTest is EVaultTestBase {

--- a/test/unit/evault/shared/Reentrancy.t.sol
+++ b/test/unit/evault/shared/Reentrancy.t.sol
@@ -2,9 +2,9 @@
 
 pragma solidity ^0.8.0;
 
-import {EVault} from "src/EVault/EVault.sol";
-import {Errors} from "src/EVault/shared/Errors.sol";
-import {IHookTarget} from "src/interfaces/IHookTarget.sol";
+import {EVault} from "../../../../src/EVault/EVault.sol";
+import {Errors} from "../../../../src/EVault/shared/Errors.sol";
+import {IHookTarget} from "../../../../src/interfaces/IHookTarget.sol";
 
 import "../EVaultTestBase.t.sol";
 

--- a/test/unit/factory/GenericFactory.t.sol
+++ b/test/unit/factory/GenericFactory.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 import {Test, console2, stdError} from "forge-std/Test.sol";
-import {GenericFactory} from "src/GenericFactory/GenericFactory.sol";
+import {GenericFactory} from "../../../src/GenericFactory/GenericFactory.sol";
 
 import {MockEVault} from "../../mocks/MockEVault.sol";
 import {TestERC20} from "../../mocks/TestERC20.sol";

--- a/test/unit/productLines/productLines.base.t.sol
+++ b/test/unit/productLines/productLines.base.t.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.0;
 
 import "../evault/EVaultTestBase.t.sol";
-import {BaseProductLine} from "src/ProductLines/BaseProductLine.sol";
+import {BaseProductLine} from "../../../src/ProductLines/BaseProductLine.sol";
 
 contract ErrorThrower {
     error NoGood();

--- a/test/unit/productLines/productLines.escrow.t.sol
+++ b/test/unit/productLines/productLines.escrow.t.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.0;
 
-import "src/ProductLines/Escrow.sol";
+import "../../../src/ProductLines/Escrow.sol";
 import "../evault/EVaultTestBase.t.sol";
 
 contract ProductLine_Escrow is EVaultTestBase {


### PR DESCRIPTION
When using the EVK repo as a dependency in another project(as in `4626-aggregator`), `forge coverage` do not recognise absolute import paths and produce the following error:
<img width="1208" alt="Screenshot 2024-05-13 at 5 10 02 PM" src="https://github.com/euler-xyz/euler-vault-kit/assets/17862704/89be928c-54e6-4ee1-bce2-93ed5007d755">

Also, there is already an inconsistency as we sometime use relative paths https://github.com/euler-xyz/euler-vault-kit/blob/master/test/unit/irm/IRMLimit.t.sol#L5 vs absolute in most cases  https://github.com/euler-xyz/euler-vault-kit/blob/master/test/unit/evault/DToken.t.sol#L5-L6.

This issue is fixed by updating all absolute paths to relative ones.