### PR TITLE
Fix typos in Certora spec files

### DIFF
--- a/certora/specs/HealthStatusInvariant.spec
+++ b/certora/specs/HealthStatusInvariant.spec
@@ -183,10 +183,10 @@ rule accountsStayHealthy_strategy (method f) filtered { f ->
 
     bool healthyBefore = checkLiquidityReturning(e, account, collaterals);
     f(e, args);
-    // The only way to call a vault funciton is through EVC's call, batch, 
+    // The only way to call a vault function is through EVC's call, batch, 
     // or permit. During all of these status checks are deferred and at the end
     // these call restoreExecutionContext which triggers the deferred checks.
-    // This excplicit call to checkStatusAll is a way to get a setup that
+    // This explicit call to checkStatusAll is a way to get a setup that
     // approximates the real situation.
     // We proved separately that EVC really does always call checkStatus all
     // at the end of a call/batch.

--- a/certora/specs/LiquidateHealthStatus.spec
+++ b/certora/specs/LiquidateHealthStatus.spec
@@ -323,7 +323,7 @@ rule liquidateAccountsStayHealthy_not_violator {
 
     bool healthyBefore = checkLiquidityReturning(e, account, collaterals);
     currentContract.liquidate(e, violator, collateral, repayAssets, minYieldBalance);
-    // The only way to call a vault funciton is through EVC's call, batch, 
+    // The only way to call a vault function is through EVC's call, batch, 
     // or permit. During all of these status checks are deferred and at the end
     // these call restoreExecutionContext which triggers the deferred checks.
     // Replace the real call path involving the EVC calling back into the
@@ -382,7 +382,7 @@ rule liquidateAccountsStayHealthy_account_cur_contract {
 
     bool healthyBefore = checkLiquidityReturning(e, account, collaterals);
     currentContract.liquidate(e, violator, collateral, repayAssets, minYieldBalance);
-    // The only way to call a vault funciton is through EVC's call, batch, 
+    // The only way to call a vault function is through EVC's call, batch, 
     // or permit. During all of these status checks are deferred and at the end
     // these call restoreExecutionContext which triggers the deferred checks.
     // Replace the real call path involving the EVC calling back into the


### PR DESCRIPTION
## Summary
Fixed typos in Certora specification files:
- HealthStatusInvariant.spec: "funciton" to "function" (line 186) and "excplicit" to "explicit" (line 189)
- LiquidateHealthStatus.spec: "funciton" to "function" (lines 326 and 385)

## Test plan
- No functional changes, comment typo fixes only